### PR TITLE
Allow the discord bot to see which accounts are linked up

### DIFF
--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -1,6 +1,17 @@
 from django.apps import AppConfig
+from allauth.socialaccount.signals import (
+	social_account_added,
+	social_account_updated,
+	social_account_removed,
+)
+from .signals import update_discord_link_details, delete_discord_link
 
 
 class AccountsConfig(AppConfig):
 	default_auto_field = 'django.db.models.AutoField'
 	name = 'accounts'
+	
+	def ready(self):
+		social_account_added.connect(update_discord_link_details, dispatch_uid="update_on_add")
+		social_account_updated.connect(update_discord_link_details, dispatch_uid="update_on_update")
+		social_account_removed.connect(delete_discord_link, dispatch_uid="update_on_remove")

--- a/accounts/signals.py
+++ b/accounts/signals.py
@@ -1,0 +1,30 @@
+from redis import Redis
+from django.conf import settings
+
+
+def update_discord_link_details(sender, request, sociallogin, **kwargs):
+	"""
+	Callback received when a SocialAccount (Discord only at this stage) is added or updated.
+	If they:
+		- Have linked a Discord account
+		- Are a current member
+		- Are not excluded
+	Then we add them to a redis dictionary, mapping their Discord UID to their short name.
+	"""
+	social_account = sociallogin.account
+	member = social_account.user.member
+	with Redis(host=settings.REDIS_HOST, port=6379, decode_responses=True) as r:
+		if member.is_valid_member():
+			r.hset("lich:linked_accounts", social_account.uid, social_account.user.member.short_name)
+		else:
+			r.hdel("lich:linked_accounts", social_account.uid)
+	
+	
+def delete_discord_link(sender, request, socialaccount, **kwargs):
+	"""
+	Callback received when a SocialAccount (Discord only at this stage) is removed or unlinked.
+	Remove them from the redis dictionary mapping.
+	"""
+	social_account = socialaccount
+	with Redis(host=settings.REDIS_HOST, port=6379, decode_responses=True) as r:
+		r.hdel("lich:linked_accounts", social_account.uid)

--- a/accounts/tasks.py
+++ b/accounts/tasks.py
@@ -1,0 +1,34 @@
+from celery import shared_task
+from celery.utils.log import get_task_logger
+from allauth.socialaccount.models import SocialAccount
+from redis import Redis
+from django.conf import settings
+
+logger = get_task_logger(__name__)
+
+
+@shared_task(name="check_discord_account_links_task")
+def check_discord_account_links_task():
+	"""
+	Iterates through every Discord account linked to Unigames,
+	checks if they are a valid member.
+	If they are, update their entry in the Redis dict.
+	If they aren't, remove them from the Redis dict.
+	
+	Intended to be run each day.
+	"""
+	accounts = SocialAccount.objects.prefetch_related("user__member").all()
+	updated = 0
+	removed = 0
+	with Redis(host=settings.REDIS_HOST, port=6379, decode_responses=True) as r:
+		for social_account in accounts:
+			member = social_account.user.member
+			if member.is_valid_member():
+				r.hset("lich:linked_accounts", social_account.uid, member.short_name)
+				updated += 1
+			else:
+				r.hdel("lich:linked_accounts", social_account.uid)
+				removed += 1
+	logger.info(f"Updated Discord permissions for {updated} members. Removed permissions for {removed} members.")
+	
+	


### PR DESCRIPTION
The website will now update redis with the discord IDs of users who have linked accounts. This will enable the bot to determine who has linked an account or not, for future command usage