### PR TITLE
Regulations update

### DIFF
--- a/templates/pages/regulations.html
+++ b/templates/pages/regulations.html
@@ -231,7 +231,7 @@
             </li>
         </ol>
         <li>
-            The Committee may appoint consenting members to the role of Webkeeper. Webkeepers shall have the following duties and powers, in addition to those elsewhere in the Regulations:
+            The Committee may appoint members to the role of Webkeeper. Webkeepers shall have the following duties and powers, in addition to those elsewhere in the Regulations:
         </li>
         <ol class="c">
             <li>


### PR DESCRIPTION
Regulations patch notes:

- Removed mention of an extra door
- Added an extra filing cabinet key under the possession of the Treasurer
- Applicants for roles must be given results within 48 hours of committee decisions, and must be given feedback upon request
- Remove mention of UniSFA and UCC vacuum cleaners
- Incorporate the website into the long-term borrowing procedures
- Incorporate the website into the special consideration procedure for short-term items
- Minis are now short-term borrowable